### PR TITLE
Fix inline image urls with spaces in README.md

### DIFF
--- a/TI-BASIC/README.md
+++ b/TI-BASIC/README.md
@@ -3,40 +3,40 @@
 A Step-By-Step Guide to your first calculator Program
 
 ## Turn on your Calculator, and clear the homescreen
-![Step 1](./images/Capture 1.png)
+![Step 1](./images/Capture%201.png)
 
 ## Press "PRGM" button to pull up Programming Menu
-![Step 2](./images/Capture 2.png)
+![Step 2](./images/Capture%202.png)
 
 ## Select "NEW"
-![Step 3](./images/Capture 3.png)
+![Step 3](./images/Capture%203.png)
 
 ## Select "Create New" and enter a name. Hit "ENTER" When complete
-![Step 4](./images/Capture 4.png)
-![Step 5](./images/Capture 5.png)
-![Step 6](./images/Capture 6.png)
+![Step 4](./images/Capture%204.png)
+![Step 5](./images/Capture%205.png)
+![Step 6](./images/Capture%206.png)
 
 ## Open "PRGM" Menu Again (it should be different this time)
-![Step 7](./images/Capture 7.png)
+![Step 7](./images/Capture%207.png)
 
 ## Select "Disp" under the "I/O" menu
-![Step 8](./images/Capture 8.png)
-![Step 9](./images/Capture 9.png)
+![Step 8](./images/Capture%208.png)
+![Step 9](./images/Capture%209.png)
 
 ## Type in "Hello World" following "Disp" (Make sure to type in "")
-![Step 10](./images/Capture 10.png)
+![Step 10](./images/Capture%2010.png)
 
 ## Hit "2ND" and "MODE" to return to the homescreen
-![Step 11](./images/Capture 11.png)
+![Step 11](./images/Capture%2011.png)
 
 ## Reopen "PRGM" Menu
-![Step 11](./images/Capture 12.png)
+![Step 11](./images/Capture%2012.png)
 
 ## Either scroll to your new program or type in "ALPHA" + "H" (First letter of program name)
-![Step 13](./images/Capture 13.png)
+![Step 13](./images/Capture%2013.png)
 
 ## Select Your Program
-![Step 14](./images/Capture 14.png)
+![Step 14](./images/Capture%2014.png)
 
 ## Run Your Program
-![Step 15](./images/Capture 15.png)
+![Step 15](./images/Capture%2015.png)


### PR DESCRIPTION
The image URLs in the README.md for TI-BASIC were malformed, and GitHub could not parse the filenames with spaces.

I've fixed the links by replacing the space with the html code for space, %20.

