### PR TITLE
Fix inconsistent formatting in README.md

### DIFF
--- a/Scala/README.md
+++ b/Scala/README.md
@@ -11,25 +11,34 @@ Before you start installing Scala on your machine, you must have Java 1.8 or gre
 * Windows: Install [Scala binaries](http://www.scala-lang.org/download/).
 * Linux: Install  
 #### - Ubuntu and other Debian-based distro  
-    echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list  
-    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823  
-    sudo apt-get update  
-    sudo apt-get install sbt  
+```
+echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list  
+sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823  
+sudo apt-get update  
+sudo apt-get install sbt  
+```
 #### - Red Hat Enterprise Linux and other RPM-based distro  
-    curl https://bintray.com/sbt/rpm/rpm | sudo tee/etc/yum.repos.d/bintray-sbt-rpm.repo  
-    sudo yum install sbt  
+```
+curl https://bintray.com/sbt/rpm/rpm | sudo tee/etc/yum.repos.d/bintray-sbt-rpm.repo  
+sudo yum install sbt  
+```
 * MacOS: Install  
 #### - [Using Homebrew](https://brew.sh/)
-    $ brew install sbt  
+```
+$ brew install sbt
+``` 
 ##### - [Using Macports](https://www.macports.org/)
-    $ port install sbt
- 
+```
+$ port install sbt
+```
 
 ### Running Scala code
 Open a command prompt and `cd` to the folder containing your `hello-world.scala` file.
 
 In the command-prompt window, enter the following command to run the program:
 
-    scala hello-world.scala
+```
+scala hello-world.scala
+```
 
 **Congratulations! You've run your first Scala program!**

--- a/Scala/README.md
+++ b/Scala/README.md
@@ -11,18 +11,18 @@ Before you start installing Scala on your machine, you must have Java 1.8 or gre
 * Windows: Install [Scala binaries](http://www.scala-lang.org/download/).
 * Linux: Install  
 #### - Ubuntu and other Debian-based distro  
-                   echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list  
-                    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823  
-                    sudo apt-get update  
-                    sudo apt-get install sbt  
+    echo "deb https://dl.bintray.com/sbt/debian /" | sudo tee -a /etc/apt/sources.list.d/sbt.list  
+    sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 2EE0EA64E40A89B84B2DF73499E82A75642AC823  
+    sudo apt-get update  
+    sudo apt-get install sbt  
 #### - Red Hat Enterprise Linux and other RPM-based distro  
-                 curl https://bintray.com/sbt/rpm/rpm | sudo tee/etc/yum.repos.d/bintray-sbt-rpm.repo  
-                 sudo yum install sbt  
+    curl https://bintray.com/sbt/rpm/rpm | sudo tee/etc/yum.repos.d/bintray-sbt-rpm.repo  
+    sudo yum install sbt  
 * MacOS: Install  
-# [Using Homebrew](https://brew.sh/)
-                    $ brew install sbt  
-# [Using Macports](https://www.macports.org/)
-                    $ port install sbt
+#### - [Using Homebrew](https://brew.sh/)
+    $ brew install sbt  
+##### - [Using Macports](https://www.macports.org/)
+    $ port install sbt
  
 
 ### Running Scala code
@@ -30,6 +30,6 @@ Open a command prompt and `cd` to the folder containing your `hello-world.scala`
 
 In the command-prompt window, enter the following command to run the program:
 
-`scala hello-world.scala`
+    scala hello-world.scala
 
 **Congratulations! You've run your first Scala program!**


### PR DESCRIPTION
In the Scala README.md, there were some inconsistencies in the formatting. The sub-headers under Mac installation were enormous H1-size headers, and the code to run at the bottom was in `inline code form`.