### PR TITLE
Adds Fortran 90 README.md to have procedure for MacOS and Windows

### DIFF
--- a/Fortran 90/README.md
+++ b/Fortran 90/README.md
@@ -1,33 +1,94 @@
-## Installation 
+# Fortran 90
 
-### Linux 
+## Installation
 
 If you don’t have GNU Fortran compiler, install it as shown below.
+
+### Linux
 
 ```
 $ sudo apt-get install gfortran
 ```
 
-Check if Fortran compiler is installed on your system as shown below.
+Test if the Fortran compiler installed correctly:
 ```
-$ whereis gfortran 
-
-gfortran: /usr/bin/gfortran /usr/share/man/man1/gfortran.1.gz
-
-$ which gfortran
-
-/usr/bin/gfortran
+$ gfortran
 ```
 
-## Running 
+### MacOS
 
-### Linux
+Using MacPorts or Homebrew:
+```
+$ sudo port selfupdate
+$ sudo port install gcc
+```
+Or:
+```
+$ brew install gcc
+```
 
-1. open terminal
+Test if the Fortran compiler installed correctly:
+```
+$ gfortran
+```
 
-2. cd into the folder that contains the `hello-world.f90` file
+### Windows
 
-3. Type `gfortran -ffree-form hello-world.f90`
+Using Scoop:
+```
+$ scoop install gcc
+```
 
-4. Run the object file output by fortran by running `./a.out`
+Otherwise, download the MinGW installer [here](https://sourceforge.net/projects/mingw/files/Installer/mingw-get-setup.exe/download) and unzip the file to `C:\MinGW`.
+To change the PATH so you can use it on the command line, right click the My Computer icon and select Properties. Go to the Advanced tab, and click the Enviroment Settings button. Change the top box, the user PATH, by clicking Edit, and then at the end, add:
+```
+[other PATH stuff];C:\MinGW\bin
+```
+
+Click Ok, Ok, and Ok to save and exit.
+
+Then, to install gfortran, open a command window and type
+```
+$ mingw-get install gfortran
+```
+
+To test if the Fortran compiler installed correctly:
+```
+$ gfortran
+```
+
+## Running
+
+### Linux/MacOS
+
+1. Open a terminal
+
+2. `cd` into the folder that contains the `hello-world.f90` file
+
+3. To compile:
+```
+$ gfortran hello-world.f90
+```
+
+4. To run the object file output from gfortran:
+```
+$ ./a.out
+```
+
+
+### Windows
+
+1. Open a command window
+
+2. `cd` into the folder that contains the `hello-world.f90` file
+
+3. To compile:
+```
+$ gfortran hello-world.f90
+```
+
+4. To run the object file output from gfortran:
+```
+$ a.exe
+```
 


### PR DESCRIPTION
Adds the MacOS and Windows procedure to the Fortran 90 README.md. Fixes issue #107 