### PR TITLE
Update Elixir Documentation.

### DIFF
--- a/Elixir/README.md
+++ b/Elixir/README.md
@@ -5,8 +5,8 @@
 ## Check if Elixir command line interpreter is installed on your system
 - If Elixir command line interpreter is installed, it should display the path as following on terminal
 ```
-$ whereis iex
-iex: /usr/local/bin/iex
+$ whereis elixir
+iex: /usr/local/bin/elixir
 ```
 
 ## Installing Elixir Compiler
@@ -15,14 +15,36 @@ iex: /usr/local/bin/iex
 $ sudo apt-get install elixir
 ```
 
+- Type the following on the command line for MacOS systems
+
+  * Homebrew
+  ```
+  $ brew update && brew install elixir
+  ```
+  
+  * Macports
+  ```
+  $ sudo port install elixir
+  ```
+- Type the following on the command line for Fedora 22 (and newer)
+```
+$ dnf install elixir
+```
+
+- Type the following on the command line for Arch Linux (Community repo)
+```
+$ pacman -S elixir
+```
+- Type the following on the command line for Gentoo
+```
+$ emerge --ask dev-lang/elixir
+```
 ## Running "Hello World"
 - Navigate to the directory containing `hello_world.ex` (you can do this from the terminal or command line using the `cd` command).
 - Type in the following
 ```
-$ iex hello_world.ex
-iex> HelloModule.hello
+$ elixir hello_world.ex
 Hello World
-:ok
 ```
 
 **Congratulations! You've run your first Elixir program!**


### PR DESCRIPTION
Use elixir compiler instead of the REPL (iex) and also add instructions to install Elixir in macOS and different Linux distributions